### PR TITLE
TLS Support

### DIFF
--- a/load_csv_to_mysql.py
+++ b/load_csv_to_mysql.py
@@ -110,7 +110,8 @@ con = pymysql.connect(
     user=DB_USER,
     password=DB_PASSWORD,
     database=DB_NAME,
-    port=DB_PORT
+    port=DB_PORT,
+    ssl_ca='./rds-combined-ca-bundle.pem'
 )
 
 dfs = wr.s3.read_csv(
@@ -156,8 +157,7 @@ for df in dfs:
         index=False,
         schema=DB_NAME,
         mode="append",
-        con=con,
-        ssl_ca='./rds-combined-ca-bundle.pem'
+        con=con
     )
     
 


### PR DESCRIPTION
Adds TLS support to the glue job. 

If the database user requires SSL the current implementation will fail since it will not always accept the TLS connection. 

The changes made here are pulling the CA bundle from AWS as documented here - https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html

Then specifying this CA bundle in the connection string. 